### PR TITLE
Move JWT Template token call to client-side provider from middleware

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,16 +16,16 @@ export default async function RootLayout({
   const token = headersList.get('x-tinybird-token') || ''
 
   return (
-    <html lang="en">
-      <body className={inter.className}>
-        <ClerkProvider>
+    <ClerkProvider>
+      <html lang="en">
+        <body className={inter.className}>
           <TinybirdProvider>
             <RootLayoutContent initialToken={token}>
               {children}
             </RootLayoutContent>
           </TinybirdProvider>
-        </ClerkProvider>
-      </body>
-    </html>
+        </body>
+      </html>
+    </ClerkProvider>
   )
 } 

--- a/src/app/providers/TinybirdProvider.tsx
+++ b/src/app/providers/TinybirdProvider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { createContext, useContext, useState, ReactNode } from 'react'
+import { createContext, useContext, useState, ReactNode, useEffect } from 'react'
+import { useSession } from '@clerk/nextjs'
 
 interface TinybirdContextType {
   token: string
@@ -10,7 +11,18 @@ interface TinybirdContextType {
 const TinybirdContext = createContext<TinybirdContextType | undefined>(undefined)
 
 export function TinybirdProvider({ children }: { children: ReactNode }) {
+  const { session } = useSession()
   const [token, setToken] = useState('')
+
+  useEffect(() => {
+    if (!session) return
+    async function populateToken() {
+      const token = await session?.getToken({ template: "tinybird" })
+      if (!token) return
+      setToken(token)
+    }
+    populateToken()
+  }, [session])
 
   return (
     <TinybirdContext.Provider value={{ token, setToken }}>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,30 +1,10 @@
 import { clerkMiddleware } from "@clerk/nextjs/server"
 import { NextResponse } from "next/server"
 
-export default clerkMiddleware(async (auth) => {
-  const authentication = await auth()
-  const { userId, sessionId, getToken } = authentication
-
-  // If user is not authenticated, continue without modification
-  if (!userId || !sessionId) {
-    console.log('No user or session found')
-    const response = NextResponse.next()
-    response.headers.set('x-tinybird-token', process.env.NEXT_PUBLIC_TINYBIRD_API_KEY || '')
-    return response
-  }
-
-  const token = await getToken({ template: "tinybird" })
-
-  try {
-    const response = NextResponse.next()
-    response.headers.set('x-tinybird-token', token || '')
-    return response
-  } catch (error) {
-    console.error('Middleware error:', error)
-    const response = NextResponse.next()
-    response.headers.set('x-tinybird-token', process.env.NEXT_PUBLIC_TINYBIRD_API_KEY || '')
-    return response
-  }
+export default clerkMiddleware(async () => {
+  const response = NextResponse.next()
+  response.headers.set('x-tinybird-token', process.env.NEXT_PUBLIC_TINYBIRD_API_KEY || '')
+  return response
 })
 
 export const config = {


### PR DESCRIPTION
This is in relation to the upcoming blog post that should provide better performance.

This was NOT TESTED as I do not have a Tinybird account. Please test before merging!